### PR TITLE
feat: migrate deployment to zad-actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Generate and Deploy Index
+name: Deploy
 
 on:
   workflow_dispatch:
@@ -8,9 +8,14 @@ on:
         required: true
         default: "main"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
-  POETRY_CACHE_DIR: ~/.cache/pypoetry
-  PIPX_BIN_DIR: /usr/local/bin
+  ZAD_PROJECT: tr-dev
+  ZAD_DEPLOYMENT: main
+  ZAD_COMPONENT: component-1
 
 jobs:
   deploy:
@@ -19,42 +24,23 @@ jobs:
       - name: Get GHCR package hash
         id: get_package_hash
         run: |
-            container_id=$(gh api --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /orgs/MinBZK/packages/container/task-registry/versions | jq -r '.[] | select(.metadata.container.tags | contains(["${{ inputs.image_tag }}"])) | .name')
-            echo "container_id=$container_id" >> "$GITHUB_OUTPUT"
+          container_id=$(gh api --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /orgs/MinBZK/packages/container/task-registry/versions | jq -r '.[] | select(.metadata.container.tags | contains(["${{ inputs.image_tag }}"])) | .name')
+          echo "container_id=$container_id" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: check correct name
+      - name: Check container exists
         run: |
-            if [ -z "${{steps.get_package_hash.outputs.container_id}}" ]; then
-              echo "Variable is empty. Failing the workflow."
-              exit 1
-            fi
+          if [ -z "${{ steps.get_package_hash.outputs.container_id }}" ]; then
+            echo "Container tag '${{ inputs.image_tag }}' not found. Failing the workflow."
+            exit 1
+          fi
 
-      - uses: actions/checkout@v5
+      - name: Deploy to ZAD
+        uses: RijksICTGilde/zad-actions/deploy@v1
         with:
-          repository: 'minbzk/ai-validation-infra'
-          ref: main
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-
-      - name: Make changes to the file
-        run: |
-          sed -i 's/newTag: .*$/newTag: ${{inputs.image_tag  }}@${{ steps.get_package_hash.outputs.container_id }}/g' apps/task-registry/sandbox/kustomization.yaml
-          sed -i 's|minbzk.github.io/version: .*$|minbzk.github.io/version: main|g' apps/task-registry/sandbox/kustomization.yaml
-          git add apps/task-registry/sandbox/kustomization.yaml
-
-      - name: show changes
-        run: git diff --staged
-
-      - name: push changes
-        run: |
-          git commit -m "Update task-registry sandbox tag ${{ steps.get_package_hash.outputs.container_id }}"
-          git push --force-with-lease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: ${{ env.ZAD_PROJECT }}
+          deployment-name: ${{ env.ZAD_DEPLOYMENT }}
+          component: ${{ env.ZAD_COMPONENT }}
+          image: ghcr.io/minbzk/task-registry:${{ inputs.image_tag }}@${{ steps.get_package_hash.outputs.container_id }}


### PR DESCRIPTION
## Summary

Migrate the deployment from GitOps-based approach to direct API-based deployment using [RijksICTGilde/zad-actions](https://github.com/RijksICTGilde/zad-actions).

**Changes:**
- Remove ai-validation-infra repository checkout and sed commands
- Use `zad-actions/deploy` action for direct deployment to ZAD Operations Manager
- Add concurrency control to prevent overlapping deployments

**ZAD Configuration:**
| Project | Deployment | Component |
|---------|------------|-----------|
| tr-dev | main | component-1 |

## Required Setup

Before merging, add the following secret to this repository:

| Secret | Purpose | How to obtain |
|--------|---------|---------------|
| `ZAD_API_KEY` | ZAD Operations Manager API authentication | Request from RIG-cluster team or self-service portal |

## Post-merge cleanup

After verifying the new deployment works:
- The `GH_PAT` secret is no longer needed for this workflow and can be removed

## Notes

- This is a pure migration - same trigger (workflow_dispatch), simpler deployment mechanism
- The workflow now uses environment variables for ZAD configuration, making it easy to update if needed

## Documentation

- [zad-actions README](https://github.com/RijksICTGilde/zad-actions)
- [ZAD Operations Manager API](https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api)